### PR TITLE
update vite to fix xss vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "quotefault",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@axa-fr/react-oidc": "^7.7.0",
         "@fortawesome/fontawesome-svg-core": "^6.4.2",
@@ -3220,9 +3221,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
-      "integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",


### PR DESCRIPTION
vite 4.5.0 has a cross-site scripting vulnerability. Please update to resolve this vulnerability.
